### PR TITLE
Fix: Typo

### DIFF
--- a/src/Nullable.php
+++ b/src/Nullable.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(sctrict_types=1);
+declare(strict_types=1);
 
 namespace Spatie\Typed;
 


### PR DESCRIPTION
This PR

* [x] fixes a small typo

💁‍♂️ Running

```
$ vendor/bin/phpunit
```

on current `master` yields

```
PHP Warning:  Unsupported declare 'sctrict_types' in /Users/am/Sites/spatie/typed/src/Nullable.php on line 3

Warning: Unsupported declare 'sctrict_types' in /Users/am/Sites/spatie/typed/src/Nullable.php on line 3
```