### PR TITLE
Fix: Move tests into appropriate namespace

### DIFF
--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1,13 +1,10 @@
 <?php
 
-namespace Spatie\Typed\Tests\Typed;
+namespace Spatie\Typed\Tests;
 
 use TypeError;
 use Spatie\Typed\T;
 use Spatie\Typed\Collection;
-use Spatie\Typed\Tests\Post;
-use Spatie\Typed\Tests\Wrong;
-use Spatie\Typed\Tests\TestCase;
 use Spatie\Typed\Lists\IntegerList;
 
 class CollectionTest extends TestCase

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -1,17 +1,13 @@
 <?php
 
-namespace Spatie\Typed\Tests\Typed\Typed;
+namespace Spatie\Typed\Tests;
 
 use TypeError;
 use Spatie\Typed\T;
 use Spatie\Typed\Tuple;
 use Spatie\Typed\Struct;
 use Spatie\Typed\Collection;
-use Spatie\Typed\Tests\Post;
-use Spatie\Typed\Tests\Wrong;
-use Spatie\Typed\Tests\TestCase;
 use Spatie\Typed\Lists\GenericList;
-use Spatie\Typed\Tests\HelperClass;
 use Spatie\Typed\Types\GenericType;
 
 class ErrorTest extends TestCase

--- a/tests/StructTest.php
+++ b/tests/StructTest.php
@@ -1,12 +1,10 @@
 <?php
 
-namespace Spatie\Typed\Tests\Typed;
+namespace Spatie\Typed\Tests;
 
 use TypeError;
 use Spatie\Typed\T;
 use Spatie\Typed\Struct;
-use Spatie\Typed\Tests\Wrong;
-use Spatie\Typed\Tests\TestCase;
 
 class StructTest extends TestCase
 {

--- a/tests/TupleTest.php
+++ b/tests/TupleTest.php
@@ -1,12 +1,9 @@
 <?php
 
-namespace Spatie\Typed\Tests\Typed;
+namespace Spatie\Typed\Tests;
 
 use Spatie\Typed\T;
 use Spatie\Typed\Tuple;
-use Spatie\Typed\Tests\Post;
-use Spatie\Typed\Tests\Wrong;
-use Spatie\Typed\Tests\TestCase;
 use Spatie\Typed\Types\StringType;
 use Spatie\Typed\Types\BooleanType;
 use Spatie\Typed\Types\IntegerType;

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -1,13 +1,10 @@
 <?php
 
-namespace Spatie\Typed\Tests\Typed;
+namespace Spatie\Typed\Tests;
 
 use TypeError;
 use Spatie\Typed\T;
 use Spatie\Typed\Collection;
-use Spatie\Typed\Tests\Post;
-use Spatie\Typed\Tests\Wrong;
-use Spatie\Typed\Tests\TestCase;
 use Spatie\Typed\Types\ArrayType;
 use Spatie\Typed\Types\FloatType;
 use Spatie\Typed\Types\StringType;


### PR DESCRIPTION
This PR

* [x] moves tests into the appropriate namespace