### PR TITLE
Fix: Consistently use test annotation

### DIFF
--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -10,7 +10,7 @@ use Spatie\Typed\Lists\IntegerList;
 class CollectionTest extends TestCase
 {
     /** @test */
-    public function test_collection()
+    public function collection()
     {
         $list = new IntegerList();
 
@@ -24,7 +24,7 @@ class CollectionTest extends TestCase
     }
 
     /** @test */
-    public function test_wrong_offset_set()
+    public function wrong_offset_set()
     {
         $this->expectException(TypeError::class);
 
@@ -64,7 +64,7 @@ class CollectionTest extends TestCase
     }
 
     /** @test */
-    public function test_nullable_collection()
+    public function nullable_collection()
     {
         $list = new Collection(T::nullable(T::int()));
 

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -13,7 +13,7 @@ use Spatie\Typed\Types\GenericType;
 class ErrorTest extends TestCase
 {
     /** @test */
-    public function test_simple_stacktrace()
+    public function simple_stacktrace()
     {
         $list = new GenericList(Post::class);
 
@@ -29,7 +29,7 @@ class ErrorTest extends TestCase
     }
 
     /** @test */
-    public function test_nested_stacktrace()
+    public function nested_stacktrace()
     {
         $list = new Collection(new GenericType(Post::class));
 
@@ -45,7 +45,7 @@ class ErrorTest extends TestCase
     }
 
     /** @test */
-    public function test_class_backtrace()
+    public function class_backtrace()
     {
         try {
             new HelperClass();
@@ -55,7 +55,7 @@ class ErrorTest extends TestCase
     }
 
     /** @test */
-    public function test_tuple_backtrace()
+    public function tuple_backtrace()
     {
         $tuple = new Tuple(T::generic(Wrong::class), T::generic(Wrong::class));
 
@@ -71,7 +71,7 @@ class ErrorTest extends TestCase
     }
 
     /** @test */
-    public function test_struct_backtrace()
+    public function struct_backtrace()
     {
         $struct = new Struct([
             'name' => T::string(),

--- a/tests/StructTest.php
+++ b/tests/StructTest.php
@@ -9,7 +9,7 @@ use Spatie\Typed\Struct;
 class StructTest extends TestCase
 {
     /** @test */
-    public function test_struct()
+    public function struct()
     {
         $struct = new Struct([
             'name' => T::string(),

--- a/tests/TupleTest.php
+++ b/tests/TupleTest.php
@@ -11,7 +11,7 @@ use Spatie\Typed\Types\IntegerType;
 class TupleTest extends TestCase
 {
     /** @test */
-    public function test_tuple()
+    public function tuple()
     {
         $data = (new Tuple(
             new IntegerType(),
@@ -23,7 +23,7 @@ class TupleTest extends TestCase
     }
 
     /** @test */
-    public function test_wrong_type()
+    public function wrong_type()
     {
         $this->expectException(\TypeError::class);
 
@@ -33,7 +33,7 @@ class TupleTest extends TestCase
     }
 
     /** @test */
-    public function test_wrong_amount()
+    public function wrong_amount()
     {
         $this->expectException(\TypeError::class);
 
@@ -43,7 +43,7 @@ class TupleTest extends TestCase
     }
 
     /** @test */
-    public function test_offset_too_large()
+    public function offset_too_large()
     {
         $this->expectException(\TypeError::class);
 
@@ -53,7 +53,7 @@ class TupleTest extends TestCase
     }
 
     /** @test */
-    public function test_offset_does_not_exist()
+    public function offset_does_not_exist()
     {
         $this->expectException(\TypeError::class);
 
@@ -63,7 +63,7 @@ class TupleTest extends TestCase
     }
 
     /** @test */
-    public function test_wrong_type_for_offset()
+    public function wrong_type_for_offset()
     {
         $this->expectException(\TypeError::class);
 
@@ -73,7 +73,7 @@ class TupleTest extends TestCase
     }
 
     /** @test */
-    public function test_offset_set()
+    public function offset_set()
     {
         $tuple = new Tuple(T::int(), T::string(), T::bool(), T::nullable(T::generic(Post::class)), T::int()->nullable());
 

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -33,7 +33,7 @@ class TypeTest extends TestCase
      * @test
      * @dataProvider failProvider
      */
-    public function fail($type, $value)
+    public function fails($type, $value)
     {
         $this->expectException(TypeError::class);
 

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -20,7 +20,7 @@ class TypeTest extends TestCase
      * @test
      * @dataProvider successProvider
      */
-    public function test_success($type, $value)
+    public function success($type, $value)
     {
         $collection = new Collection($type);
 
@@ -33,7 +33,7 @@ class TypeTest extends TestCase
      * @test
      * @dataProvider failProvider
      */
-    public function test_fail($type, $value)
+    public function fail($type, $value)
     {
         $this->expectException(TypeError::class);
 


### PR DESCRIPTION
This PR

* [x] consistently uses the `@test` annotation along with snake-cased test method names

💁‍♂️ I ran

```
$ composer global require friendsofphp/php-cs-fixer
```

followed by running

```
$ php-cs-fixer fix tests --allow-risky=yes --diff --rules='{"php_unit_test_annotation": {"case": "snake", "style": "annotation"}}' --using-cache=no --verbose
```

For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.11.1#usage:

>**php_unit_test_annotation**
>
>Adds or removes `@test` annotations from tests, following configuration.
>
>Risky rule: this fixer may change the name of your tests, and could cause incompatibility with abstract classes or interfaces.
>
>Configuration options:
>
>* `case` (`'camel'`, `'snake'`): whether to camel or snake case when adding the test prefix; defaults to `'camel'`
>* `style` (`'annotation'`, `'prefix'`): whether to use the `@test` annotation or not; defaults to `'prefix'`
