### PR TITLE
Enhance assertions to assert correct results

### DIFF
--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -96,13 +96,13 @@ class CollectionTest extends TestCase
         $list[] = null;
 
         foreach ($list as $i) {
-            $this->assertEquals(null, $i);
+            $this->assertNull($i);
         }
 
         $list[] = 1;
 
-        $this->assertEquals(null, $list[0]);
-        $this->assertEquals(null, $list[1]);
+        $this->assertNull($list[0]);
+        $this->assertNull($list[1]);
         $this->assertEquals(1, $list[2]);
     }
 

--- a/tests/StructTest.php
+++ b/tests/StructTest.php
@@ -33,7 +33,7 @@ class StructTest extends TestCase
 
         $this->assertEquals('BrenDt', $struct['name']);
         $this->assertEquals(23, $struct->age);
-        $this->assertEquals(null, $struct['second_name']);
+        $this->assertNull($struct['second_name']);
     }
 
     /** @test */

--- a/tests/TupleTest.php
+++ b/tests/TupleTest.php
@@ -25,7 +25,7 @@ class TupleTest extends TestCase
             new BooleanType())
         )->set(1, 'a', true);
 
-        $this->assertTrue(is_array($data->toArray()));
+        $this->assertInternalType('array', $data->toArray());
     }
 
     /** @test */
@@ -81,8 +81,8 @@ class TupleTest extends TestCase
 
         $this->assertEquals(1, $tuple[0]);
         $this->assertEquals('a', $tuple[1]);
-        $this->assertEquals(true, $tuple[2]);
-        $this->assertEquals(null, $tuple[3]);
+        $this->assertTrue($tuple[2]);
+        $this->assertNull($tuple[3]);
     }
 
     /** @test */

--- a/tests/UnionTypeTest.php
+++ b/tests/UnionTypeTest.php
@@ -20,8 +20,8 @@ class UnionTypeTest extends TestCase
         $list[] = 1;
         $list[] = 1.1;
 
-        $this->assertTrue(1 === $list[0]);
-        $this->assertTrue(1.1 === $list[1]);
+        $this->assertSame(1, $list[0]);
+        $this->assertSame(1.1, $list[1]);
     }
 
     /** @test */


### PR DESCRIPTION
# Changed log
- Using `assertSame` to assert whether the actual result is strict equal to expected value.
- Using `assertInternalType` to assert whether actual result is the `array` type.
- Using `assertNull` to assert whether actual result is the `null`.