### PR TITLE
Add the possibility to call Collection::set with the "iterable" type and small test fixes/improvements

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -36,7 +36,7 @@ class Collection implements ArrayAccess, Iterator, Countable
         $this->set($type);
     }
 
-    public function set(array $data): self
+    public function set(iterable $data): self
     {
         foreach ($data as $item) {
             $this[] = $item;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Spatie\Typed;
 
-use Iterator;
-use Countable;
 use ArrayAccess;
+use Countable;
+use Iterator;
 
 class Collection implements ArrayAccess, Iterator, Countable
 {

--- a/tests/Benchmarks/BenchmarkTest.php
+++ b/tests/Benchmarks/BenchmarkTest.php
@@ -59,4 +59,11 @@ EOL;
     {
         return round($bytes / 1000000, 3).' MB';
     }
+
+    protected function range()
+    {
+        foreach (range(1, 1000000) as $i) {
+            yield $i;
+        }
+    }
 }

--- a/tests/Benchmarks/ListBenchmarkTest.php
+++ b/tests/Benchmarks/ListBenchmarkTest.php
@@ -14,7 +14,7 @@ class ListBenchmarkTest extends BenchmarkTest
 
         $this->startTimer();
 
-        foreach (range(1, 1000000) as $i) {
+        foreach ($this->range() as $i) {
             $array[] = $i;
         }
 
@@ -30,7 +30,7 @@ class ListBenchmarkTest extends BenchmarkTest
 
         $this->startTimer();
 
-        foreach (range(1, 1000000) as $i) {
+        foreach ($this->range() as $i) {
             $list[] = $i;
         }
 
@@ -42,7 +42,7 @@ class ListBenchmarkTest extends BenchmarkTest
     {
         $array = [];
 
-        foreach (range(1, 1000000) as $i) {
+        foreach ($this->range() as $i) {
             $array[] = $i;
         }
 
@@ -62,7 +62,7 @@ class ListBenchmarkTest extends BenchmarkTest
     {
         $list = new Collection(T::int());
 
-        foreach (range(1, 1000000) as $i) {
+        foreach ($this->range() as $i) {
             $list[] = $i;
         }
 

--- a/tests/Benchmarks/ListBenchmarkTest.php
+++ b/tests/Benchmarks/ListBenchmarkTest.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Typed\Tests\Benchmarks;
 
-use Spatie\Typed\T;
 use Spatie\Typed\Collection;
+use Spatie\Typed\T;
 
 class ListBenchmarkTest extends BenchmarkTest
 {

--- a/tests/Benchmarks/TupleBenchmarkTest.php
+++ b/tests/Benchmarks/TupleBenchmarkTest.php
@@ -10,20 +10,39 @@ class TupleBenchmarkTest extends BenchmarkTest
     /** @test */
     public function array_write()
     {
-        $this->start();
+        $this->startTimer();
 
-        $tuple = [1, 'a'];
+        foreach ($this->range() as $item) {
+            $tuple = [1, 'a'];
+        }
 
-        $this->stop();
+        $this->output('array write', $this->stopTimer());
     }
 
     /** @test */
     public function tuple_write()
     {
-        $this->start();
+        $this->startTimer();
 
-        $tuple = (new Tuple(T::int(), T::string()))->set([1, 'a']);
+        $tuple = new Tuple(T::int(), T::string());
+        foreach ($this->range() as $item) {
+            $tuple[0] = 1;
+            $tuple[1] = 'a';
+        }
 
-        $this->stop();
+        $this->output('tuple write', $this->stopTimer());
+    }
+
+    /** @test */
+    public function tuple_write_set()
+    {
+        $this->startTimer();
+
+        $tuple = new Tuple(T::int(), T::string());
+        foreach ($this->range() as $item) {
+            $tuple->set(1, 'a');
+        }
+
+        $this->output('tuple write via set method', $this->stopTimer());
     }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Spatie\Typed\Tests;
 
 use ArrayIterator;
-use TypeError;
-use Spatie\Typed\T;
 use Spatie\Typed\Collection;
-use Spatie\Typed\Tests\Extra\Post;
 use Spatie\Typed\Lists\IntegerList;
+use Spatie\Typed\T;
+use Spatie\Typed\Tests\Extra\Post;
 use Spatie\Typed\Tests\Extra\Wrong;
+use TypeError;
 
 class CollectionTest extends TestCase
 {

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spatie\Typed\Tests;
 
+use ArrayIterator;
 use TypeError;
 use Spatie\Typed\T;
 use Spatie\Typed\Collection;
@@ -49,6 +50,48 @@ class CollectionTest extends TestCase
         $this->expectException(TypeError::class);
 
         $list[] = new Wrong();
+    }
+
+    /** @test */
+    public function a_collection_set_method_can_accept_array()
+    {
+        $list = new IntegerList();
+        $list->set([1]);
+        foreach ($list as $i) {
+            $this->assertEquals(1, $i);
+        }
+
+        $this->assertEquals(1, $list[0]);
+    }
+
+    /** @test */
+    public function a_collection_set_method_can_accept_generator()
+    {
+        $generator = function () {
+            yield 1;
+        };
+
+        $list = new IntegerList();
+        $list->set($generator());
+        foreach ($list as $i) {
+            $this->assertEquals(1, $i);
+        }
+
+        $this->assertEquals(1, $list[0]);
+    }
+
+    /** @test */
+    public function a_collection_set_method_can_accept_iterator()
+    {
+        $iterator = new ArrayIterator([1]);
+
+        $list = new IntegerList();
+        $list->set($iterator);
+        foreach ($list as $i) {
+            $this->assertEquals(1, $i);
+        }
+
+        $this->assertEquals(1, $list[0]);
     }
 
     /** @test */


### PR DESCRIPTION
Changelog:
- change the "\Spatie\Typed\Collection::set" argument from "array" to "iterable"
- fix the "\Spatie\Typed\Tests\Benchmarks\TupleBenchmarkTest"
- add the "\Spatie\Typed\Tests\Benchmarks\BenchmarkTest::range"