### PR TITLE
Allow Collection to be emptied

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -105,4 +105,9 @@ class Collection implements ArrayAccess, Iterator, Countable
     {
         return count($this->data);
     }
+
+    public function clear(): void
+    {
+        $this->data = [];
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -158,4 +158,18 @@ class CollectionTest extends TestCase
 
         $this->assertSame([1, 2, 3], $list->toArray());
     }
+
+    /** @test */
+    public function it_removes_all_elements_in_the_collection()
+    {
+        $list = new Collection(T::int());
+
+        $list[] = 1;
+        $list[] = 2;
+        $list[] = 3;
+
+        $list->clear();
+
+        $this->assertCount(0, $list);
+    }
 }


### PR DESCRIPTION
I think this can be useful, in my case it's in a generator method, i need to yield a collection of x items, but at the moment i need to recreate a new Collection instance with the same parameters everytime the collection reach the size limit and the results are returned.